### PR TITLE
only remove stale documents an a connect, and skipUpdate for the tracker hook

### DIFF
--- a/companion-packages/meteorrn-local/index.js
+++ b/companion-packages/meteorrn-local/index.js
@@ -1,4 +1,4 @@
-import { Mongo, packageInterface } from '@meteorrn/core';
+import { Mongo, packageInterface, Tracker } from '@meteorrn/core';
 
 const stringifiedDateRegExp = new RegExp(
   /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z/
@@ -96,11 +96,12 @@ const Local = {
 
       LiveCol.find({}).observe({
         added: async (doc) => {
-          LocalCol._collection.upsert(doc);
+          LocalCol.insert(doc);
           storeLocalCol();
         },
-        changed: async (doc) => {
-          LocalCol._collection.upsert(doc);
+        changed: async (changes, oldDoc) => {
+          delete changes._id;
+          LocalCol.update(oldDoc._id, { $set: changes });
           storeLocalCol();
         },
       });

--- a/companion-packages/meteorrn-local/index.js
+++ b/companion-packages/meteorrn-local/index.js
@@ -1,4 +1,4 @@
-import { Mongo, packageInterface, Tracker } from '@meteorrn/core';
+import { Mongo, packageInterface } from '@meteorrn/core';
 
 const stringifiedDateRegExp = new RegExp(
   /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z/

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -158,7 +158,7 @@ const Meteor = {
             }
           }
         }
-      }, 4000);
+      }, 8000);
 
       if (isVerbose) {
         console.info('Connected to DDP server.');

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -166,8 +166,9 @@ const Meteor = {
               }
             }
           }
+          Data.notify('change');
         }
-      }, 15000);
+      }, 8000);
     });
 
     let lastDisconnect = null;

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -139,6 +139,17 @@ const Meteor = {
     Data.ddp.on('connected', () => {
       // Don't clear out all the date; instead, after a brief timeout, remove all docs that are still marked as stale
       // ddp add ond change events will set the _stale flag to false
+
+      if (isVerbose) {
+        console.info('Connected to DDP server.');
+      }
+      this._loadInitialUser().then(() => {
+        this._subscriptionsRestart();
+      });
+      this._reactiveDict.set('connected', true);
+      this.connected = true;
+      Data.notify('change');
+
       setTimeout(() => {
         if (Data.db && Data.db.collections) {
           for (var collection in Data.db.collections) {
@@ -152,23 +163,11 @@ const Meteor = {
 
               if (isVerbose) {
                 console.info('Removed stale entries of ' + collection);
-                //console.info(Data.db[collection].findOne({}))
               }
-              //Data.db[collection].remove({});
             }
           }
         }
-      }, 8000);
-
-      if (isVerbose) {
-        console.info('Connected to DDP server.');
-      }
-      this._loadInitialUser().then(() => {
-        this._subscriptionsRestart();
-      });
-      this._reactiveDict.set('connected', true);
-      this.connected = true;
-      Data.notify('change');
+      }, 15000);
     });
 
     let lastDisconnect = null;

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -153,10 +153,7 @@ const Meteor = {
       setTimeout(() => {
         if (Data.db && Data.db.collections) {
           for (var collection in Data.db.collections) {
-            if (
-              !localCollections.includes(collection) &&
-              collection != 'users'
-            ) {
+            if (!localCollections.includes(collection)) {
               // Dont clear data from local collections
 
               Data.db[collection].remove({ _stale: true });
@@ -168,7 +165,7 @@ const Meteor = {
           }
           Data.notify('change');
         }
-      }, 8000);
+      }, 5000);
     });
 
     let lastDisconnect = null;

--- a/src/components/useTracker.js
+++ b/src/components/useTracker.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useReducer, useMemo } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import Tracker from '../Tracker.js';
 
 function useForceUpdate() {
@@ -32,21 +32,22 @@ export default (trackerFn, deps = [], skipUpdate) => {
       refs.computation = null;
     }
     Tracker.nonreactive(() => {
-      Tracker.autorun((currentComputation) => {
-        if (refs.isMounted) {
-          refs.computation = currentComputation;
-          refs.data = trackerFn();
-          if (
-            !(
-              skipUpdate &&
-              typeof skipUpdate === 'function' &&
-              skipUpdate(prev, data)
-            )
-          ) {
+      Tracker.autorun((currentComputation) => {         
+        const data = trackerFn()
+        const prev = refs.data
+        if (currentComputation.firstRun){
+          refs.data = data;
+        } else if (refs.isMounted) {
+          refs.computation = currentComputation
+
+          if (!(skipUpdate && typeof skipUpdate === "function" && skipUpdate(prev, data))) {
+            refs.data = data
             forceUpdate();
+          } else {
+            refs.data = data
           }
         } else {
-          refs.computation?.stop();
+            refs.computation?.stop();
         }
       });
     });

--- a/src/components/useTracker.js
+++ b/src/components/useTracker.js
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useReducer, useMemo } from 'react';
 import Tracker from '../Tracker.js';
 
-const fur = (x: number): number => x + 1;
-const useForceUpdate = () => useReducer(fur, 0)[1];
+function useForceUpdate() {
+  const [, forceUpdate] = useState(0);
+
+  return useCallback(() => {
+    forceUpdate(s => s+1);
+  }, []);
+}
+
 export default (trackerFn, deps = []) => {
   const { current: refs } = useRef({
     data: null,

--- a/src/components/useTracker.js
+++ b/src/components/useTracker.js
@@ -32,22 +32,28 @@ export default (trackerFn, deps = [], skipUpdate) => {
       refs.computation = null;
     }
     Tracker.nonreactive(() => {
-      Tracker.autorun((currentComputation) => {         
-        const data = trackerFn()
-        const prev = refs.data
-        if (currentComputation.firstRun){
+      Tracker.autorun((currentComputation) => {
+        const data = trackerFn();
+        const prev = refs.data;
+        if (currentComputation.firstRun) {
           refs.data = data;
         } else if (refs.isMounted) {
-          refs.computation = currentComputation
+          refs.computation = currentComputation;
 
-          if (!(skipUpdate && typeof skipUpdate === "function" && skipUpdate(prev, data))) {
-            refs.data = data
+          if (
+            !(
+              skipUpdate &&
+              typeof skipUpdate === 'function' &&
+              skipUpdate(prev, data)
+            )
+          ) {
+            refs.data = data;
             forceUpdate();
           } else {
-            refs.data = data
+            refs.data = data;
           }
         } else {
-            refs.computation?.stop();
+          refs.computation?.stop();
         }
       });
     });


### PR DESCRIPTION
If there's a (re)connect, then all docs are removed completely and then readded via initial ddp `added` events. This can result in flashing ui, since items disappear and then reappear after being readded.

I guess this was considered necessary, since during the time with no connection to the server, there may be docs that get removed from the db, and the somehow the client needs to get those docs removed aswell as soon as it is reconnected.

This PR solves this by marking all docs as `_stale` on a disconnect. After a reconnect, docs will get initially added via ddp, and will be flagged as not being `_stale` anymore.

After a certain timeout following a (re)connect (bet there's a better place to do this? if all subs are ready maybe?), all docs, that were removed on the server are still flagged as `_stale`. Now all `_stale` docs can be safely removed from the client.

Also adds the `skipUpdate` callback to the `useTracker` hook, as known from react-meteor-data.