### PR TITLE
Fix loginWithToken when token is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ const {AsyncStorage} = Meteor.packageInterface();
 
 <hr/>
 
-Meteor React Native is maintained by [Nathaniel Dsouza](github.com/therealnate) who is available for consultation: nate@hiyllo.com
+Meteor React Native is maintained by [Nathaniel Dsouza](github.com/therealnate) who is available for consultation: nate@notaiyet.io

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorrn/core",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Full Meteor Client for React Native",
   "main": "src/index.js",
   "repository": {

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -177,7 +177,11 @@ const User = {
             }
             this._loadInitialUser();
           }, time + 100);
-        } else {
+        }
+        else if (err?.error === 403) {
+          User.logout();
+        } 
+        else {
           User._handleLoginCallback(err, result);
         }
       });

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -177,11 +177,9 @@ const User = {
             }
             this._loadInitialUser();
           }, time + 100);
-        }
-        else if (err?.error === 403) {
+        } else if (err?.error === 403) {
           User.logout();
-        } 
-        else {
+        } else {
           User._handleLoginCallback(err, result);
         }
       });


### PR DESCRIPTION
Hi!

After we upgraded to 2.4+ we got some issues related to loginWithToken. After some investigation, it seemed that after the login token expired, it tried to loginWithToken again and again even though it was logged out by the server with [403].

I added a small fix, better suggestions are welcome.

Here's a small video with an invalid token:


https://github.com/meteorrn/meteor-react-native/assets/9382283/cec2d195-c598-4747-9c81-03680d379db8


