### PR TITLE
set subs to not ready on disconnect

### DIFF
--- a/lib/ddp.js
+++ b/lib/ddp.js
@@ -115,6 +115,7 @@ export default class DDP extends EventEmitter {
     this.socket.on('message:in', (message) => {
       if (message.msg === 'connected') {
         this.status = 'connected';
+        this._lastSessionId = message.session;
         this.messageQueue.process();
         this.emit('connected');
       } else if (message.msg === 'ping') {

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -50,6 +50,11 @@ const Meteor = {
   disconnect() {
     if (Data.ddp) {
       Data.ddp.disconnect();
+      for (var i in Data.subscriptions) {
+        const sub = Data.subscriptions[i];
+        sub.ready = false;
+        sub.readyDeps.changed();
+      }
     }
   },
   _subscriptionsRestart() {

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -50,11 +50,6 @@ const Meteor = {
   disconnect() {
     if (Data.ddp) {
       Data.ddp.disconnect();
-      for (var i in Data.subscriptions) {
-        const sub = Data.subscriptions[i];
-        sub.ready = false;
-        sub.readyDeps.changed();
-      }
     }
   },
   _subscriptionsRestart() {
@@ -172,6 +167,13 @@ const Meteor = {
 
       if (isVerbose) {
         console.info('Disconnected from DDP server.');
+      }
+
+      // Mark subscriptions as ready=false
+      for (var i in Data.subscriptions) {
+        const sub = Data.subscriptions[i];
+        sub.ready = false;
+        sub.readyDeps.changed();
       }
 
       if (!Data.ddp.autoReconnect) return;


### PR DESCRIPTION
Hi all,

I'm still not really happy with how the tracker behaves, especially after disconnects. I found out two things:

1. On a `connected` event, all stale data is removed from all collections.
2. On a `disconnected` event, all subs remain in `ready` state.

This results in the following: Say you disconnect from your server once your app is sent to background. When you bring your app back to foreground, the connection is reestablished and all docs get removed and then _initially_ added again. During all this, all sub handlers are in `ready === true` state. Ultimately, this leads to flashing UI and bad UX, since in the normal UI design pattern you pick up any sort of _loading_ / _refreshing_ state from `handle.ready()`.

I already tried to work around to somehow get rid of no 1 (eg. only remove stale docs or something similar). But actually we know that no matter how you implement this part, you need to transfer all the changes / removals that happened during your offline-time from the server. But, of course, in this case, you definitely should be able to inform your user about a reloading state in your UI instead of just removing all docs in front of his eyes and then re-adding them.

This PR implements a more canonical behavior of the ready state of subs when a disconnect happens. In this case, all subs are flagged as not ready. So if you (re)connect, they will simply reload, and all handlers will report that accordingly.

Using this, you can then easily implement an offline-first version of `useTracker`, that stores tracker results eg. in AsyncStorage, once the corresponding sub is ready and fetches data offline first, if the app is not connected or the sub is not ready yet, and displays live data once the sub is ready. I'm currently testing this on iOS and even on Edge networks this leads to a really responsive UI.

I also tried to put the new LOC marking subs as not-ready in the `Meteor.disconnect()` method, but of course then you miss disconnections coming from the server side.