### PR TITLE
add 2fa login

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,7 +65,16 @@ Returns true if attempting to login
 
 Returns true if attempting to logout
 
-### `Meteor.loginWithPassword`
+### `Meteor.loginWithPassword(selector, password, callback)`
+
+Logs a user in. If selector is a string containing `@`, then this will be interpreted as an email, other strings as a username. The selector can also be an object with a single key `email`, `id` or `username`.
+The optional Callback is called with a single `Error` argument on failure.
+
+If 2fa is enabled, the `error` property of the argument may be `no-2fa-code`. Read more in [the Meteor docs](https://docs.meteor.com/api/accounts#Meteor-loginWithPassword)
+
+### `Meteor.loginWithPasswordAnd2faCode(selector, password, code, callback)`
+
+Logs a user in, same as `loginWithPassword`, but providing a 2fa token via the argument `code`. Read more on this [in the Meteor docs](https://docs.meteor.com/packages/accounts-2fa.html).
 
 ### `Meteor.logout`
 

--- a/src/user/User.js
+++ b/src/user/User.js
@@ -73,6 +73,28 @@ const User = {
       }
     );
   },
+  loginWithPasswordAnd2faCode(selector, password, code, callback) {
+    this._isTokenLogin = false;
+    if (typeof selector === 'string') {
+      if (selector.indexOf('@') === -1) selector = { username: selector };
+      else selector = { email: selector };
+    }
+
+    User._startLoggingIn();
+    Meteor.call(
+      'login',
+      {
+        user: selector,
+        password: hashPassword(password),
+        code,
+      },
+      (err, result) => {
+        User._handleLoginCallback(err, result);
+
+        typeof callback == 'function' && callback(err);
+      }
+    );
+  },
   logoutOtherClients(callback = () => {}) {
     Meteor.call('getNewToken', (err, res) => {
       if (err) return callback(err);


### PR DESCRIPTION
Loggin in to a 2fa enabled account is the first thing to do imho. Enabling 2fa for accounts could be added as well, but the main use case will be to enable 2fa in browser and using a 2fa app on your mobile device, hence this is not a primary thing to implement in this client.