### PR TITLE
feature: make NetInfo injectable/truly optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meteorrn/core",
-  "version": "2.7.0",
+  "version": "2.8.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meteorrn/core",
-      "version": "2.7.0",
+      "version": "2.8.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@meteorrn/minimongo": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteorrn/core",
-  "version": "2.7.1",
+  "version": "2.8.0-rc.0",
   "description": "Full Meteor Client for React Native",
   "main": "src/index.js",
   "repository": {

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -109,29 +109,37 @@ const Meteor = {
       ...options,
     });
 
-    try {
-      const NetInfo = require('@react-native-community/netinfo').default;
+    if (options.NetInfo !== null) {
+      try {
+        const NetInfo = getNetInfo();
 
-      if (options.reachabilityUrl) {
-        NetInfo.configure({
-          reachabilityUrl: options.reachabilityUrl,
-          useNativeReachability: true,
-        });
-      }
-
-      // Reconnect if we lose internet
-
-      NetInfo.addEventListener(
-        ({ type, isConnected, isInternetReachable, isWifiEnabled }) => {
-          if (isConnected && Data.ddp.autoReconnect) {
-            Data.ddp.connect();
-          }
+        if (options.reachabilityUrl) {
+          NetInfo.configure({
+            reachabilityUrl: options.reachabilityUrl,
+            useNativeReachability: true,
+          });
         }
-      );
-    } catch (e) {
+
+        // Reconnect if we lose internet
+
+        NetInfo.addEventListener(
+          ({ type, isConnected, isInternetReachable, isWifiEnabled }) => {
+            if (isConnected && Data.ddp.autoReconnect) {
+              Data.ddp.connect();
+            }
+          }
+        );
+      } catch (e) {
+        console.warn(
+          'Warning: NetInfo not installed, so DDP will not automatically reconnect'
+        );
+        Data.ddp.connect();
+      }
+    } else {
       console.warn(
         'Warning: NetInfo not installed, so DDP will not automatically reconnect'
       );
+      Data.ddp.connect();
     }
 
     Data.ddp.on('connected', () => {
@@ -425,5 +433,8 @@ const Meteor = {
     return handle;
   },
 };
+
+const getNetInfo = (NetInfo) =>
+  NetInfo ? NetInfo : require('@react-native-community/netinfo').default;
 
 export default Meteor;

--- a/src/Meteor.js
+++ b/src/Meteor.js
@@ -111,7 +111,7 @@ const Meteor = {
 
     if (options.NetInfo !== null) {
       try {
-        const NetInfo = getNetInfo();
+        const NetInfo = getNetInfo(options.NetInfo);
 
         if (options.reachabilityUrl) {
           NetInfo.configure({

--- a/test/src/Meteor.tests.js
+++ b/test/src/Meteor.tests.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import Meteor from '../../src/Meteor';
+import { awaitDisconnected, stub, restoreAll } from '../testHelpers';
+import DDP from '../../lib/ddp';
 
 describe('Meteor - integration', function () {
   it('uses the default async storage if none is defined', function () {
@@ -7,5 +9,53 @@ describe('Meteor - integration', function () {
       require('@react-native-async-storage/async-storage').default;
     const { AsyncStorage } = Meteor.packageInterface();
     expect(AsyncStorage).to.equal(fallback);
+  });
+
+  describe(Meteor.connect.name, () => {
+    before(awaitDisconnected);
+    afterEach(() => {
+      restoreAll();
+    });
+    it('allows to bypass NetInfo', (done) => {
+      stub(DDP.prototype, 'on', () => {});
+      stub(DDP.prototype, 'connect', done);
+
+      const AsyncStorage = {
+        getItem: async () => {},
+        setItem: async () => {},
+        removeItem: async () => {},
+      };
+
+      const endpoint = `ws://localhost:3000/websocket`;
+      Meteor.connect(endpoint, {
+        AsyncStorage,
+        NetInfo: null,
+        autoConnect: false,
+      });
+    });
+    it('allows to pass a custom configured NetInfo', (done) => {
+      stub(DDP.prototype, 'on', () => {});
+      stub(DDP.prototype, 'connect', done);
+
+      const AsyncStorage = {
+        getItem: async () => {},
+        setItem: async () => {},
+        removeItem: async () => {},
+      };
+
+      const NetInfo = {
+        addEventListener: (cb) => {
+          setTimeout(() => cb({ isConnected: true }), 300);
+        },
+      };
+
+      const endpoint = `ws://localhost:3000/websocket`;
+      Meteor.connect(endpoint, {
+        AsyncStorage,
+        NetInfo,
+        autoConnect: false,
+        autoReconnect: true,
+      });
+    });
   });
 });

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -1,0 +1,49 @@
+import sinon from 'sinon';
+import Meteor from '../src/Meteor';
+
+export const stubs = new Map();
+
+export const stub = (target, name, handler) => {
+  if (stubs.get(target)) {
+    throw new Error(`already stubbed: ${name}`);
+  }
+  const stubbedTarget = sinon.stub(target, name);
+  if (typeof handler === 'function') {
+    stubbedTarget.callsFake(handler);
+  } else {
+    stubbedTarget.value(handler);
+  }
+  stubs.set(stubbedTarget, name);
+};
+
+export const restore = (target, name) => {
+  if (!target[name] || !target[name].restore) {
+    throw new Error(`not stubbed: ${name}`);
+  }
+  target[name].restore();
+  stubs.delete(target);
+};
+
+export const overrideStub = (target, name, handler) => {
+  restore(target, name);
+  stub(target, name, handler);
+};
+
+export const restoreAll = () => {
+  stubs.forEach((name, target) => {
+    stubs.delete(target);
+    target.restore();
+  });
+};
+
+export const awaitDisconnected = async () => {
+  Meteor.disconnect();
+  await new Promise((resolve) => {
+    let timer = setInterval(() => {
+      if (Meteor.status().status === 'disconnected') {
+        clearInterval(timer);
+        resolve();
+      }
+    }, 100);
+  });
+};


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------- 

🎉 THANK YOU FOR YOUR CONTRIBUTION! 🎉

We highly appreciate your time and effort to this project!


⚠ PLEASE READ THIS FIRST ⚠

1. If this is a fix for a security vulnerability you discovered please don't 
just open this PR until we have privately discussed the vulnerability. Disclosing 
it without contacting us can lead to severe implications for many applications 
that run on this project.

2. Make sure you have read the contribution guidelines for this project in
order to raise the chance of getting your PR accepted. This saves you valuable 
time and effort.

3. The following structure is a basic guideline. If a section does not apply you
can remove it.
---------------------------------------------------------------------------- -->

## Summary
<!-- ---------------------------------------------------------------------------
⚠ Provide one or two paragraphs
---------------------------------------------------------------------------- -->
This makes NetInfo a true optional dependency.

If Meteor.connect options contain `NetInfo: null` it will not be imported and not used. Users need to manually connect/reconnect.

If the options is a custom NetInfo (injected) then this will be used.

Otherwise the default NetInfo is loaded.

This allows also to configure netinfo in a much more custom basis than previously.


## Linked issue(s)
<!-- ---------------------------------------------------------------------------
⚠ Please make sure we have discussed this PR in an issue beore, while this
  may not apply to trivial PRs (small fixes, typo fixes, depdency bumps),
  this applies especially to features and changes to the API.
---------------------------------------------------------------------------- -->
#143 


## Involved parts of the project
<!-- ---------------------------------------------------------------------------
⚠ Which parts of the code is affected the most?
---------------------------------------------------------------------------- -->
Meteor.connect / DDP.connect


## Added tests?
<!-- ---------------------------------------------------------------------------
⚠ Did you add tests that cover your changes, if any?
---------------------------------------------------------------------------- -->
yes


## Targeted Meteor release version
<!-- ---------------------------------------------------------------------------
⚠ This section is important in order to review compliance with the Meteor
  backend and API.
---------------------------------------------------------------------------- -->
-


## Reproduction
<!-- ---------------------------------------------------------------------------
⚠ How can we reproduce your changes in an app? This is especially important
when new features are added
---------------------------------------------------------------------------- -->
Clone, ceckout branch, run tests
A test release is provided soon