### PR TITLE
Feature: Refactor and update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@meteorrn/core",
   "version": "2.9.0",
   "description": "Full Meteor Client for React Native",
+  "types": "src/Meteor.d.ts",
   "main": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/Meteor.d.ts
+++ b/src/Meteor.d.ts
@@ -1,9 +1,8 @@
+import { AsyncStorageStatic } from "@react-native-async-storage/async-storage";
+
 declare module '@meteorrn/core' {
   type Callback = (...args: unknown[]) => void;
-
-  function connect(endpoint: string, options?: any): void;
-  function disconnect(): void;
-  function reconnect(): void;
+  
   type Status =
     | 'change'
     | 'connected'
@@ -11,15 +10,7 @@ declare module '@meteorrn/core' {
     | 'loggingIn'
     | 'loggingOut';
 
-  function call(...args: any[]): void;
-  function status(): {
-    connected: boolean;
-    status: Status;
-  };
-
-  function logout(cb: Callback): void;
-  function loggingOut(): boolean;
-  function loggingIn(): boolean;
+  type useTracker<T> = (cb: () => T) => T
 
   interface Data {
     getUrl(): string;
@@ -35,7 +26,12 @@ declare module '@meteorrn/core' {
       socket: unknown;
     };
   }
-  function getData(): Data;
+
+  interface MeteorError {
+    error: string
+    reason?: string
+    details?: string
+  }
 
   interface User {
     _id: string;
@@ -45,15 +41,53 @@ declare module '@meteorrn/core' {
       settings: {};
     };
   }
-  function user(): User | undefined;
+
+  interface ConnectOptions {
+    suppressUrlErrors: boolean
+    AsyncStorage: AsyncStorageStatic
+    reachabilityUrl: string
+  }
+
+  interface Meteor {
+    connect(endpoint: string, options?: ConnectOptions): void;
+    disconnect(): void;
+    reconnect(): void;
+
+    call(...args: any[]): void;
+    status(): {
+      connected: boolean;
+      status: Status;
+    };
+
+    logout(cb: Callback): void;
+    loggingOut(): boolean;
+    loggingIn(): boolean;
+
+    getData(): Data;
+    user(): User | undefined;
+    getAuthToken(): string;
+
+    readonly isVerbose: boolean;
+    enableVerbose(): void;
+
+    useTracker<T>(): useTracker<T>;
+
+    ddp: Data; 
+
+    _handleLoginCallback(err?: MeteorError, res: { token: string, id: string }): void;
+  }
+
   interface Accounts {
     onLogin(cb: Callback): void;
   }
-  function getAuthToken(): string;
 
-  const ddp: Data;
-  let isVerbose: boolean;
-  function _handleLoginCallback(err: any, res: any): void;
+  // Export default Meteor object
+  const Meteor: Meteor;
+  export default Meteor;
 
-  function useTracker<T>(cb: () => T): T;
+  // Export other members
+  export {
+    useTracker,
+    Accounts,
+  }
 }

--- a/src/Meteor.d.ts
+++ b/src/Meteor.d.ts
@@ -1,8 +1,8 @@
-import { AsyncStorageStatic } from "@react-native-async-storage/async-storage";
+import { AsyncStorageStatic } from '@react-native-async-storage/async-storage';
 
 declare module '@meteorrn/core' {
   type Callback = (...args: unknown[]) => void;
-  
+
   type Status =
     | 'change'
     | 'connected'
@@ -10,7 +10,7 @@ declare module '@meteorrn/core' {
     | 'loggingIn'
     | 'loggingOut';
 
-  type useTracker<T> = (cb: () => T) => T
+  type useTracker<T> = (cb: () => T) => T;
 
   interface Data {
     getUrl(): string;
@@ -28,9 +28,9 @@ declare module '@meteorrn/core' {
   }
 
   interface MeteorError {
-    error: string
-    reason?: string
-    details?: string
+    error: string;
+    reason?: string;
+    details?: string;
   }
 
   interface User {
@@ -43,9 +43,9 @@ declare module '@meteorrn/core' {
   }
 
   interface ConnectOptions {
-    suppressUrlErrors: boolean
-    AsyncStorage: AsyncStorageStatic
-    reachabilityUrl: string
+    suppressUrlErrors: boolean;
+    AsyncStorage: AsyncStorageStatic;
+    reachabilityUrl: string;
   }
 
   interface Meteor {
@@ -72,9 +72,12 @@ declare module '@meteorrn/core' {
 
     useTracker<T>(): useTracker<T>;
 
-    ddp: Data; 
+    ddp: Data;
 
-    _handleLoginCallback(err: MeteorError | null | undefined, res: { token: string, id: string }): void;
+    _handleLoginCallback(
+      err: MeteorError | null | undefined,
+      res: { token: string; id: string }
+    ): void;
   }
 
   interface Accounts {
@@ -86,8 +89,5 @@ declare module '@meteorrn/core' {
   export default Meteor;
 
   // Export other members
-  export {
-    useTracker,
-    Accounts,
-  }
+  export { useTracker, Accounts };
 }

--- a/src/Meteor.d.ts
+++ b/src/Meteor.d.ts
@@ -74,7 +74,7 @@ declare module '@meteorrn/core' {
 
     ddp: Data; 
 
-    _handleLoginCallback(err?: MeteorError, res: { token: string, id: string }): void;
+    _handleLoginCallback(err: MeteorError | null | undefined, res: { token: string, id: string }): void;
   }
 
   interface Accounts {


### PR DESCRIPTION
## Summary
This is a refactor for the `Meteor.d.ts` declaration file. I used this library in my last job position and I couldn't help but notice that not only the `types` field from `package.json` was not defined but the types were not correctly exported. I refactored the declaration file based on the existing types but this does not represent the actual state of the library. I'm open to discuss next steps to manage the types correctly and refactor or expand it as necessary.

## Linked issue(s)
This is not related to any issue.

## Involved parts of the project
Types, possibly JDoc. This is more related to dev experience.

## Added tests?
Since this is a refactor for existing types, I did not add any tests. 

## Targeted Meteor release version
This is not related to any meteor version.

## Reproduction
Before: Importing types would fail or require workarounds
After: Types can be imported normally in both JS and TS projects

Example: `import Meteor from 'meteor'`
